### PR TITLE
Feature implementation from commits f558476..087c003

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,22 @@
 # Detailed changelog
 The most important changes can also be found in [the documentation](https://docs.locust.io/en/latest/changelog.html).
 
+## [2.37.5](https://github.com/locustio/locust/tree/2.37.5) (2025-05-22)
+
+[Full Changelog](https://github.com/locustio/locust/compare/2.37.4...2.37.5)
+
+**Fixed bugs:**
+
+- Web UI Does Not Switch to Details Page Immediately on Test Start in Current Version [\#3128](https://github.com/locustio/locust/issues/3128)
+
+**Merged pull requests:**
+
+- Do not require locustfile on specific locust-cloud arguments [\#3141](https://github.com/locustio/locust/pull/3141) ([amadeuppereira](https://github.com/amadeuppereira))
+
+## [2.37.4](https://github.com/locustio/locust/tree/2.37.4) (2025-05-19)
+
+[Full Changelog](https://github.com/locustio/locust/compare/2.37.3...2.37.4)
+
 ## [2.37.3](https://github.com/locustio/locust/tree/2.37.3) (2025-05-14)
 
 [Full Changelog](https://github.com/locustio/locust/compare/2.37.2...2.37.3)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,10 @@ Changelog Highlights
 
 For full details of changes, please see https://github.com/locustio/locust/releases or https://github.com/locustio/locust/blob/master/CHANGELOG.md
 
+2.37.6
+======
+* Doc updates, including a fix for config options https://github.com/locustio/locust/pull/3145
+
 2.37.5
 ======
 * Locust Cloud: Stop requiring a locustfile when doing --login or --delete https://github.com/locustio/locust/pull/3141

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,14 @@ Changelog Highlights
 
 For full details of changes, please see https://github.com/locustio/locust/releases or https://github.com/locustio/locust/blob/master/CHANGELOG.md
 
+2.37.5
+======
+* Locust Cloud: Stop requiring a locustfile when doing --login or --delete https://github.com/locustio/locust/pull/3141
+
+2.37.4
+======
+* Bump minimum version of locust-cloud
+
 2.37.3
 ======
 * Webui: Warn on Missing Host https://github.com/locustio/locust/pull/3140

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,9 +4,14 @@ Changelog Highlights
 
 For full details of changes, please see https://github.com/locustio/locust/releases or https://github.com/locustio/locust/blob/master/CHANGELOG.md
 
+2.37.7
+======
+* Web Ui: Add host field validation https://github.com/locustio/locust/pull/3149
+
 2.37.6
 ======
 * Doc updates, including a fix for config options https://github.com/locustio/locust/pull/3145
+* Bumped minimum ConfigArgParse dependency to 1.7.1
 
 2.37.5
 ======

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -65,7 +65,7 @@ def save_locust_env_variables():
                     ", ".join([f"``{c}``" for c in action.option_strings]),
                     f"``{action.env_var}``",
                     ", ".join([f"``{c}``" for c in parser.get_possible_config_keys(action) if not c.startswith("--")]),
-                    action.help,
+                    action.help.replace("\n", " "),
                 )
             )
     colsizes = [max(len(r[i]) for r in table_data) for i in range(len(table_data[0]))]

--- a/docs/extensions.rst
+++ b/docs/extensions.rst
@@ -23,11 +23,6 @@ Report OTEL traces for requests
 
 - `opentelemetry-demo repo <https://github.com/open-telemetry/opentelemetry-demo/tree/main/src/load-generator>`__
 
-Automate distributed runs over SSH
-----------------------------------
-
--  `locust-swarm <https://github.com/SvenskaSpel/locust-swarm/>`__
-
 Automatically translate a browser recording (HAR-file) to a locustfile
 ----------------------------------------------------------------------
 

--- a/docs/running-distributed.rst
+++ b/docs/running-distributed.rst
@@ -50,6 +50,9 @@ And then on each worker machine:
 Multiple machines, using locust-swarm
 =====================================
 
+.. note::
+    locust-swarm is no longer actively maintained. Check out the hosted :ref:`Locust Cloud <locust-cloud>` instead!
+
 When you make changes to the locustfile you'll need to restart all Locust processes. `locust-swarm <https://github.com/SvenskaSpel/locust-swarm>`_ automates this for you. It also solves the issue of firewall/network access from workers to master using SSH tunnels (this is often a problem if the master is running on your workstation and workers are running in some datacenter).
 
 .. code-block:: bash
@@ -58,7 +61,6 @@ When you make changes to the locustfile you'll need to restart all Locust proces
 
     swarm -f my_locustfile.py --loadgen-list worker-server1,worker-server2 <any other regular locust parameters>
 
-See `locust-swarm <https://github.com/SvenskaSpel/locust-swarm>`_ for more details.
 
 Options for distributed load generation
 =======================================

--- a/locust/argument_parser.py
+++ b/locust/argument_parser.py
@@ -330,19 +330,21 @@ def raise_argument_type_error(err_msg):
 # Definitions for some "types" to use with the arguments
 
 
+def timespan(time_str) -> int:
+    try:
+        return parse_timespan(time_str)
+    except ValueError as e:
+        raise configargparse.ArgumentTypeError(str(e))
+
+
+# A locustfile "type" to be used in argparse that returns a list of local files.
+# It supports urls, directories and files
 def locustfile(files):
     if files == "-":
         return files
 
     locustfile_list = [f.strip() for f in files.split(",")]
     return parse_locustfile_paths(locustfile_list)
-
-
-def timespan(time_str) -> int:
-    try:
-        return parse_timespan(time_str)
-    except ValueError as e:
-        raise configargparse.ArgumentTypeError(str(e))
 
 
 def positive_integer(string) -> int:

--- a/locust/main.py
+++ b/locust/main.py
@@ -158,7 +158,8 @@ def merge_locustfiles_content(
 
 
 def main():
-    # parse all command line options
+    # find specified locustfile(s) and make sure it exists, using a very simplified
+    # command line parser that is only used to parse the -f option.
     options, unknown = parse_locustfile_option()
 
     if any([flag for flag in ["--login", "--logout", "--delete"] if flag in unknown]):
@@ -174,6 +175,7 @@ def main():
         shape_class,
     ) = merge_locustfiles_content(locustfiles)
 
+    # parse all command line options
     options = parse_options()
 
     if getattr(options, "cloud", None):

--- a/locust/test/test_load_locustfile.py
+++ b/locust/test/test_load_locustfile.py
@@ -10,7 +10,7 @@ import textwrap
 
 from .mock_locustfile import MOCK_LOCUSTFILE_CONTENT, mock_locustfile
 from .testcases import LocustTestCase
-from .util import temporary_file
+from .util import get_locustfiles_from_args, temporary_file
 
 
 class TestLoadLocustfile(LocustTestCase):
@@ -209,16 +209,16 @@ class TestLoadLocustfile(LocustTestCase):
             self.assertEqual("my_locust_file.py", options.locustfile)
 
     def test_locustfile_from_url(self):
-        options = parse_options(
+        locustfiles = get_locustfiles_from_args(
             args=[
                 "-f",
                 "https://raw.githubusercontent.com/locustio/locust/master/examples/basic.py",
             ]
         )
-        self.assertEqual(len(options.locustfile), 1)
+        self.assertEqual(len(locustfiles), 1)
         self.assertTrue(
             filecmp.cmp(
-                options.locustfile[0],
+                locustfiles[0],
                 f"{os.getcwd()}/examples/basic.py",
             )
         )

--- a/locust/test/test_load_locustfile.py
+++ b/locust/test/test_load_locustfile.py
@@ -1,5 +1,5 @@
 from locust import main
-from locust.argument_parser import parse_locustfile_option, parse_options
+from locust.argument_parser import parse_options
 from locust.main import create_environment
 from locust.user import HttpUser, TaskSet, User
 from locust.util.load_locustfile import is_user_class
@@ -209,16 +209,16 @@ class TestLoadLocustfile(LocustTestCase):
             self.assertEqual("my_locust_file.py", options.locustfile)
 
     def test_locustfile_from_url(self):
-        locustfiles = parse_locustfile_option(
+        options = parse_options(
             args=[
                 "-f",
                 "https://raw.githubusercontent.com/locustio/locust/master/examples/basic.py",
             ]
         )
-        self.assertEqual(len(locustfiles), 1)
+        self.assertEqual(len(options.locustfile), 1)
         self.assertTrue(
             filecmp.cmp(
-                locustfiles[0],
+                options.locustfile[0],
                 f"{os.getcwd()}/examples/basic.py",
             )
         )

--- a/locust/test/test_parser.py
+++ b/locust/test/test_parser.py
@@ -14,11 +14,7 @@ from unittest import mock
 
 from .mock_locustfile import mock_locustfile
 from .testcases import LocustTestCase
-
-
-def _get_parsed_locustfile(*args, **kwargs):
-    options = parse_options(*args, **kwargs)
-    return options.locustfile
+from .util import get_locustfiles_from_args
 
 
 class TestParser(unittest.TestCase):
@@ -157,7 +153,7 @@ class TestArgumentParser(LocustTestCase):
 
     def test_parse_locustfile(self):
         with mock_locustfile() as mocked:
-            locustfiles = _get_parsed_locustfile(
+            locustfiles = get_locustfiles_from_args(
                 args=[
                     "-f",
                     mocked.file_path,
@@ -176,7 +172,7 @@ class TestArgumentParser(LocustTestCase):
             locustfile = locustfiles[0]
             self.assertEqual(mocked.file_path, locustfile)
             assert len(locustfiles) == 1
-            locustfiles = _get_parsed_locustfile(
+            locustfiles = get_locustfiles_from_args(
                 args=[
                     "-f",
                     mocked.file_path,
@@ -189,7 +185,7 @@ class TestArgumentParser(LocustTestCase):
     def test_parse_locustfile_multiple_files(self):
         with mock_locustfile() as mocked1:
             with mock_locustfile(dir=self.parent_dir.name) as mocked2:
-                locustfiles = _get_parsed_locustfile(
+                locustfiles = get_locustfiles_from_args(
                     args=[
                         "-f",
                         f"{mocked1.file_path},{mocked2.file_path}",
@@ -202,7 +198,7 @@ class TestArgumentParser(LocustTestCase):
 
     def test_parse_locustfile_with_directory(self):
         with mock_locustfile(dir=self.parent_dir.name) as mocked:
-            locustfiles = _get_parsed_locustfile(
+            locustfiles = get_locustfiles_from_args(
                 args=[
                     "-f",
                     self.parent_dir.name,
@@ -224,7 +220,7 @@ class TestArgumentParser(LocustTestCase):
         with mock_locustfile(filename_prefix="mock_locustfile1", dir=self.parent_dir.name) as mock_locustfile1:
             with mock_locustfile(filename_prefix="mock_locustfile2", dir=self.child_dir.name) as mock_locustfile2:
                 with mock_locustfile(filename_prefix="mock_locustfile3", dir=self.child_dir.name) as mock_locustfile3:
-                    locustfiles = _get_parsed_locustfile(
+                    locustfiles = get_locustfiles_from_args(
                         args=[
                             "-f",
                             self.parent_dir.name,
@@ -239,7 +235,7 @@ class TestArgumentParser(LocustTestCase):
         with NamedTemporaryFile(suffix=".py", prefix="_", dir=self.parent_dir.name) as invalid_file1:
             with NamedTemporaryFile(suffix=".txt", prefix="", dir=self.parent_dir.name) as invalid_file2:
                 with mock_locustfile(filename_prefix="mock_locustfile1", dir=self.parent_dir.name) as mock_locustfile1:
-                    locustfiles = _get_parsed_locustfile(
+                    locustfiles = get_locustfiles_from_args(
                         args=[
                             "-f",
                             self.parent_dir.name,
@@ -253,7 +249,7 @@ class TestArgumentParser(LocustTestCase):
     def test_parse_locustfile_empty_directory_error(self):
         with mock.patch("sys.stderr", new=StringIO()):
             with self.assertRaises(SystemExit):
-                _get_parsed_locustfile(
+                get_locustfiles_from_args(
                     args=[
                         "-f",
                         self.parent_dir.name,
@@ -264,7 +260,7 @@ class TestArgumentParser(LocustTestCase):
         with mock_locustfile(filename_prefix="mock_locustfile1", dir=self.parent_dir.name) as mock_locustfile1:
             with mock_locustfile(filename_prefix="mock_locustfile2", dir=self.parent_dir.name) as mock_locustfile2:
                 with mock_locustfile(filename_prefix="mock_locustfile3", dir=self.child_dir.name) as mock_locustfile3:
-                    locustfiles = _get_parsed_locustfile(
+                    locustfiles = get_locustfiles_from_args(
                         args=[
                             "-f",
                             f"{mock_locustfile1.file_path},{self.child_dir.name}",
@@ -277,7 +273,7 @@ class TestArgumentParser(LocustTestCase):
     def test_parse_multiple_directories(self):
         with mock_locustfile(filename_prefix="mock_locustfile1", dir=self.child_dir.name) as mock_locustfile1:
             with mock_locustfile(filename_prefix="mock_locustfile2", dir=self.child_dir2.name) as mock_locustfile2:
-                locustfiles = _get_parsed_locustfile(
+                locustfiles = get_locustfiles_from_args(
                     args=[
                         "-f",
                         f"{self.child_dir.name},{self.child_dir2.name}",
@@ -290,7 +286,7 @@ class TestArgumentParser(LocustTestCase):
     def test_parse_locustfile_invalid_directory_error(self):
         with mock.patch("sys.stderr", new=StringIO()):
             with self.assertRaises(SystemExit):
-                _get_parsed_locustfile(
+                get_locustfiles_from_args(
                     args=[
                         "-f",
                         "non_existent_dir",

--- a/locust/test/test_parser.py
+++ b/locust/test/test_parser.py
@@ -1,7 +1,6 @@
 import locust
 from locust.argument_parser import (
     get_parser,
-    parse_locustfile_option,
     parse_locustfile_paths,
     parse_options,
     ui_extra_args_dict,
@@ -15,6 +14,11 @@ from unittest import mock
 
 from .mock_locustfile import mock_locustfile
 from .testcases import LocustTestCase
+
+
+def _get_parsed_locustfile(*args, **kwargs):
+    options = parse_options(*args, **kwargs)
+    return options.locustfile
 
 
 class TestParser(unittest.TestCase):
@@ -153,7 +157,7 @@ class TestArgumentParser(LocustTestCase):
 
     def test_parse_locustfile(self):
         with mock_locustfile() as mocked:
-            locustfiles = parse_locustfile_option(
+            locustfiles = _get_parsed_locustfile(
                 args=[
                     "-f",
                     mocked.file_path,
@@ -172,7 +176,7 @@ class TestArgumentParser(LocustTestCase):
             locustfile = locustfiles[0]
             self.assertEqual(mocked.file_path, locustfile)
             assert len(locustfiles) == 1
-            locustfiles = parse_locustfile_option(
+            locustfiles = _get_parsed_locustfile(
                 args=[
                     "-f",
                     mocked.file_path,
@@ -185,7 +189,7 @@ class TestArgumentParser(LocustTestCase):
     def test_parse_locustfile_multiple_files(self):
         with mock_locustfile() as mocked1:
             with mock_locustfile(dir=self.parent_dir.name) as mocked2:
-                locustfiles = parse_locustfile_option(
+                locustfiles = _get_parsed_locustfile(
                     args=[
                         "-f",
                         f"{mocked1.file_path},{mocked2.file_path}",
@@ -198,7 +202,7 @@ class TestArgumentParser(LocustTestCase):
 
     def test_parse_locustfile_with_directory(self):
         with mock_locustfile(dir=self.parent_dir.name) as mocked:
-            locustfiles = parse_locustfile_option(
+            locustfiles = _get_parsed_locustfile(
                 args=[
                     "-f",
                     self.parent_dir.name,
@@ -220,7 +224,7 @@ class TestArgumentParser(LocustTestCase):
         with mock_locustfile(filename_prefix="mock_locustfile1", dir=self.parent_dir.name) as mock_locustfile1:
             with mock_locustfile(filename_prefix="mock_locustfile2", dir=self.child_dir.name) as mock_locustfile2:
                 with mock_locustfile(filename_prefix="mock_locustfile3", dir=self.child_dir.name) as mock_locustfile3:
-                    locustfiles = parse_locustfile_option(
+                    locustfiles = _get_parsed_locustfile(
                         args=[
                             "-f",
                             self.parent_dir.name,
@@ -235,7 +239,7 @@ class TestArgumentParser(LocustTestCase):
         with NamedTemporaryFile(suffix=".py", prefix="_", dir=self.parent_dir.name) as invalid_file1:
             with NamedTemporaryFile(suffix=".txt", prefix="", dir=self.parent_dir.name) as invalid_file2:
                 with mock_locustfile(filename_prefix="mock_locustfile1", dir=self.parent_dir.name) as mock_locustfile1:
-                    locustfiles = parse_locustfile_option(
+                    locustfiles = _get_parsed_locustfile(
                         args=[
                             "-f",
                             self.parent_dir.name,
@@ -249,7 +253,7 @@ class TestArgumentParser(LocustTestCase):
     def test_parse_locustfile_empty_directory_error(self):
         with mock.patch("sys.stderr", new=StringIO()):
             with self.assertRaises(SystemExit):
-                parse_locustfile_option(
+                _get_parsed_locustfile(
                     args=[
                         "-f",
                         self.parent_dir.name,
@@ -260,7 +264,7 @@ class TestArgumentParser(LocustTestCase):
         with mock_locustfile(filename_prefix="mock_locustfile1", dir=self.parent_dir.name) as mock_locustfile1:
             with mock_locustfile(filename_prefix="mock_locustfile2", dir=self.parent_dir.name) as mock_locustfile2:
                 with mock_locustfile(filename_prefix="mock_locustfile3", dir=self.child_dir.name) as mock_locustfile3:
-                    locustfiles = parse_locustfile_option(
+                    locustfiles = _get_parsed_locustfile(
                         args=[
                             "-f",
                             f"{mock_locustfile1.file_path},{self.child_dir.name}",
@@ -273,7 +277,7 @@ class TestArgumentParser(LocustTestCase):
     def test_parse_multiple_directories(self):
         with mock_locustfile(filename_prefix="mock_locustfile1", dir=self.child_dir.name) as mock_locustfile1:
             with mock_locustfile(filename_prefix="mock_locustfile2", dir=self.child_dir2.name) as mock_locustfile2:
-                locustfiles = parse_locustfile_option(
+                locustfiles = _get_parsed_locustfile(
                     args=[
                         "-f",
                         f"{self.child_dir.name},{self.child_dir2.name}",
@@ -286,7 +290,7 @@ class TestArgumentParser(LocustTestCase):
     def test_parse_locustfile_invalid_directory_error(self):
         with mock.patch("sys.stderr", new=StringIO()):
             with self.assertRaises(SystemExit):
-                parse_locustfile_option(
+                _get_parsed_locustfile(
                     args=[
                         "-f",
                         "non_existent_dir",

--- a/locust/test/util.py
+++ b/locust/test/util.py
@@ -1,3 +1,5 @@
+from locust.argument_parser import get_locustfiles_locally, parse_locustfile_option
+
 import datetime
 import functools
 import gc
@@ -86,3 +88,8 @@ def clear_all_functools_lru_cache() -> None:
     assert len(wrappers) > 0
     for wrapper in wrappers:
         wrapper.cache_clear()
+
+
+def get_locustfiles_from_args(*args, **kwargs):
+    options, _ = parse_locustfile_option(*args, **kwargs)
+    return get_locustfiles_locally(options)

--- a/locust/webui/src/components/SwarmForm/SwarmForm.tsx
+++ b/locust/webui/src/components/SwarmForm/SwarmForm.tsx
@@ -23,6 +23,7 @@ import Select from 'components/Form/Select';
 import CustomParameters from 'components/SwarmForm/SwarmCustomParameters';
 import SwarmUserClassPicker from 'components/SwarmForm/SwarmUserClassPicker';
 import { SWARM_STATE } from 'constants/swarm';
+import useForm from 'hooks/useForm';
 import { useStartSwarmMutation } from 'redux/api/swarm';
 import { useSelector } from 'redux/hooks';
 import { swarmActions } from 'redux/slice/swarm.slice';
@@ -30,6 +31,8 @@ import { IRootState } from 'redux/store';
 import { ICustomInput } from 'types/form.types';
 import { ISwarmFormInput, ISwarmState } from 'types/swarm.types';
 import { isEmpty } from 'utils/object';
+
+const URL_VALIDATION_REGEX = /^(?:[a-zA-Z][a-zA-Z\d+\-.]*):\/\/[^\s/$.?#].[^\s]*$/;
 
 interface IDispatchProps {
   setSwarm: (swarmPayload: Partial<ISwarmState>) => void;
@@ -127,6 +130,20 @@ function SwarmForm({
   const [errorMessage, setErrorMessage] = useState('');
   const [selectedUserClasses, setSelectedUserClasses] = useState(availableUserClasses);
   const swarm = useSelector(({ swarm }) => swarm);
+  const { register } = useForm();
+  const hostFieldProps = isHostRequired
+    ? register(
+        'host',
+        {
+          match: {
+            pattern: URL_VALIDATION_REGEX,
+            message: 'Please use a valid url format e.g. https://google.com',
+          },
+          level: 'warning',
+        },
+        'onBlur',
+      )
+    : {};
 
   const { reason: formDisabledReason, isFormDisabled } = useMemo(
     () => canSubmitSwarmForm({ isDisabled, ...swarm }),
@@ -233,8 +250,8 @@ function SwarmForm({
                     ? '(setting this will override the host for the User classes)'
                     : ''
                 }`}
-                name='host'
                 required={isHostRequired}
+                {...hostFieldProps}
               />
               <Accordion>
                 <AccordionSummary expandIcon={<ExpandMoreIcon />}>

--- a/locust/webui/src/hooks/useForm.ts
+++ b/locust/webui/src/hooks/useForm.ts
@@ -1,0 +1,81 @@
+import { ChangeEvent, useState } from 'react';
+import { AlertColor, Theme } from '@mui/material';
+
+type MatchRule = {
+  pattern: RegExp;
+  message?: string;
+};
+
+type ValidationRules = {
+  minLength?: number;
+  match?: MatchRule | MatchRule[];
+  level?: AlertColor;
+};
+
+type Errors = Record<string, string>;
+
+export default function useForm() {
+  const [errors, setErrors] = useState<Errors>({});
+  const [isValid, setIsValid] = useState<boolean>(true);
+
+  const validate = (
+    name: string,
+    value: string,
+    rules: ValidationRules,
+    { onlyDelete } = { onlyDelete: false },
+  ) => {
+    const newErrors = { ...errors };
+    let errorMessage;
+    const failedMatch =
+      rules.match &&
+      Array.isArray(rules.match) &&
+      rules.match.find(({ pattern }) => !new RegExp(pattern).test(value));
+
+    if (rules.minLength && value.length < rules.minLength) {
+      errorMessage = `Please enter at least ${rules.minLength} characters`;
+    } else if (failedMatch) {
+      errorMessage = failedMatch.message || 'Invalid format';
+    } else if (
+      rules.match &&
+      !Array.isArray(rules.match) &&
+      !new RegExp(rules.match.pattern).test(value)
+    ) {
+      errorMessage = rules.match.message || 'Invalid format';
+    } else {
+      delete newErrors[name];
+    }
+
+    if (errorMessage && !onlyDelete) {
+      newErrors[name] = errorMessage;
+    }
+
+    setErrors(newErrors);
+    setIsValid(Object.keys(newErrors).length === 0);
+  };
+
+  const register = (name: string, rules: ValidationRules, mode = 'onChange') => {
+    const alertLevelProps =
+      errors[name] && rules.level
+        ? {
+            color: rules.level,
+            focused: true,
+            FormHelperTextProps: {
+              sx: { color: (theme: Theme) => theme.palette.warning.main },
+            },
+          }
+        : {};
+
+    return {
+      ...alertLevelProps,
+      name,
+      onChange: ({ target: { value } }: ChangeEvent<HTMLInputElement>) =>
+        validate(name, value, rules, { onlyDelete: true }),
+      [mode]: ({ target: { value } }: ChangeEvent<HTMLInputElement>) =>
+        validate(name, value, rules),
+      error: !!errors[name] && !rules.level,
+      helperText: errors[name] || '',
+    };
+  };
+
+  return { register, isValid };
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ dependencies = [
     "Flask-Cors>=3.0.10",
     "pywin32; sys_platform == 'win32'",
     "setuptools>=70.0.0",
-    "locust-cloud>=1.21.5",
+    "locust-cloud>=1.21.7",
     "gevent>=24.10.1,<25.0.0",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ dependencies = [
     "Flask-Cors>=3.0.10",
     "pywin32; sys_platform == 'win32'",
     "setuptools>=70.0.0",
-    "locust-cloud>=1.21.9",
+    "locust-cloud>=1.23.0",
     "gevent>=24.10.1,<25.0.0",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ dependencies = [
     "Flask-Cors>=3.0.10",
     "pywin32; sys_platform == 'win32'",
     "setuptools>=70.0.0",
-    "locust-cloud>=1.21.7",
+    "locust-cloud>=1.21.8",
     "gevent>=24.10.1,<25.0.0",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dependencies = [
     "msgpack>=1.0.0",
     "pyzmq>=25.0.0",
     "geventhttpclient>=2.3.1",
-    "ConfigArgParse>=1.5.5",
+    "configargparse>=1.7.1",
     "tomli>=1.1.0; python_version < '3.11'",
     "typing_extensions>=4.6.0; python_version < '3.11'",
     "psutil>=5.9.1",
@@ -48,7 +48,7 @@ dependencies = [
     "Flask-Cors>=3.0.10",
     "pywin32; sys_platform == 'win32'",
     "setuptools>=70.0.0",
-    "locust-cloud>=1.21.8",
+    "locust-cloud>=1.21.9",
     "gevent>=24.10.1,<25.0.0",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -551,6 +551,12 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/92/ce/6cc6e30b66c147128d7662cf4909fe038b81792d2617a748dfe4ee0ae98a/geventhttpclient-2.3.3-pp310-pypy310_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:447fc2d49a41449684154c12c03ab80176a413e9810d974363a061b71bdbf5a0", size = 58540, upload-time = "2024-11-24T11:42:19.324Z" },
     { url = "https://files.pythonhosted.org/packages/7e/f4/5214ea44055c82d92adaaaddb19d2791addd3ce60af863aec03384e7c88a/geventhttpclient-2.3.3-pp310-pypy310_pp73-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4598c2aa14c866a10a07a2944e2c212f53d0c337ce211336ad68ae8243646216", size = 54445, upload-time = "2024-11-24T11:42:20.749Z" },
     { url = "https://files.pythonhosted.org/packages/06/1d/f65b4ac42cce6cef707ace606bbdc1142aa0f3863ad16fa615004b9461d7/geventhttpclient-2.3.3-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:69d2bd7ab7f94a6c73325f4b88fd07b0d5f4865672ed7a519f2d896949353761", size = 48838, upload-time = "2024-11-24T11:42:21.903Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/35/fd3d2f22aac238c314e4db0317634288f4c9f01b3aa0c6f36e2584b7ad2c/geventhttpclient-2.3.3-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:45a3f7e3531dd2650f5bb840ed11ce77d0eeb45d0f4c9cd6985eb805e17490e6", size = 51477, upload-time = "2025-05-15T15:09:33.849Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/4c/f64bb9cda9474c8e70a59a7aebe928e7044aaa660b81492bc783b53ea6e7/geventhttpclient-2.3.3-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:73b427e0ea8c2750ee05980196893287bfc9f2a155a282c0f248b472ea7ae3e7", size = 50731, upload-time = "2025-05-15T15:09:35.787Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/88/0a3e18cb7d73fe4110e6b75aa43361722a309276dc7cb6461594ea4f490b/geventhttpclient-2.3.3-pp311-pypy311_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c2959ef84271e4fa646c3dbaad9e6f2912bf54dcdfefa5999c2ef7c927d92127", size = 55171, upload-time = "2025-05-15T15:09:37.173Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/26/057600ba3ef9e2ca5fe9527dec4d29695cf986185b862b2947f3cc8d97b7/geventhttpclient-2.3.3-pp311-pypy311_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0a800fcb8e53a8f4a7c02b4b403d2325a16cad63a877e57bd603aa50bf0e475b", size = 59515, upload-time = "2025-05-15T15:09:38.604Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/e5/8e2fe8f3e976f11859e325b2151a7eea49677e8898229215fa8c788fe539/geventhttpclient-2.3.3-pp311-pypy311_pp73-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:528321e9aab686435ba09cc6ff90f12e577ace79762f74831ec2265eeab624a8", size = 55416, upload-time = "2025-05-15T15:09:39.553Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/68/ddfe93ab3142b16f84c31996ed01b76a32fe7e2df37104b456c1d68e3de9/geventhttpclient-2.3.3-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:034be44ff3318359e3c678cb5c4ed13efd69aeb558f2981a32bd3e3fb5355700", size = 49659, upload-time = "2025-05-15T15:09:40.993Z" },
 ]
 
 [[package]]
@@ -914,7 +920,7 @@ requires-dist = [
     { name = "flask-login", specifier = ">=0.6.3" },
     { name = "gevent", specifier = ">=24.10.1,<25.0.0" },
     { name = "geventhttpclient", specifier = ">=2.3.1" },
-    { name = "locust-cloud", specifier = ">=1.21.5" },
+    { name = "locust-cloud", specifier = ">=1.21.7" },
     { name = "msgpack", specifier = ">=1.0.0" },
     { name = "psutil", specifier = ">=5.9.1" },
     { name = "pywin32", marker = "sys_platform == 'win32'" },
@@ -969,7 +975,7 @@ test = [
 
 [[package]]
 name = "locust-cloud"
-version = "1.21.5"
+version = "1.21.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "configargparse" },
@@ -978,9 +984,9 @@ dependencies = [
     { name = "python-socketio", extra = ["client"] },
     { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/30/65/e3dfd66ede886b5f84f7767e97539aab65946a29d4dfba41039df9933989/locust_cloud-1.21.5.tar.gz", hash = "sha256:f5347c0ab7c22c151fbb9a93001c107ed3f2662584af0af9f159563df1866464", size = 450093, upload-time = "2025-05-13T10:36:32.767Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/11/d1/29e785fbe2ac6b1eda03b39709e5c898d82bd10495d181c95c0f038cb0ae/locust_cloud-1.21.7.tar.gz", hash = "sha256:a919e93e514ae48a3dd4791945188b9df6369122afc3d7d21447aafb8daa3f87", size = 450230, upload-time = "2025-05-15T14:09:51.283Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7a/41/b03da33414a21dcfb0dca5fc290afa642682a67d6af7f59b12bd2deb8b27/locust_cloud-1.21.5-py3-none-any.whl", hash = "sha256:9761738610c700aa64e87ef73dd81bd4b869e2ab5c2a7ae51a43be709b645776", size = 407350, upload-time = "2025-05-13T10:36:30.606Z" },
+    { url = "https://files.pythonhosted.org/packages/33/8d/98853ef23e96bb9372226492b40d28a1df650a064122c84e586ab267fa12/locust_cloud-1.21.7-py3-none-any.whl", hash = "sha256:93e93212a0726b8b7481ddbf82c64f5b1c7c2eb8f3c12de95834fe6ef445eb5e", size = 407883, upload-time = "2025-05-15T14:09:49.861Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -920,7 +920,7 @@ requires-dist = [
     { name = "flask-login", specifier = ">=0.6.3" },
     { name = "gevent", specifier = ">=24.10.1,<25.0.0" },
     { name = "geventhttpclient", specifier = ">=2.3.1" },
-    { name = "locust-cloud", specifier = ">=1.21.9" },
+    { name = "locust-cloud", specifier = ">=1.23.0" },
     { name = "msgpack", specifier = ">=1.0.0" },
     { name = "psutil", specifier = ">=5.9.1" },
     { name = "pywin32", marker = "sys_platform == 'win32'" },
@@ -975,7 +975,7 @@ test = [
 
 [[package]]
 name = "locust-cloud"
-version = "1.21.9"
+version = "1.23.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "configargparse" },
@@ -984,9 +984,9 @@ dependencies = [
     { name = "python-socketio", extra = ["client"] },
     { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/54/71/4f3dec44c419f7e5706e117fae7dda7c17d440d873c5e68aeb5843b7c9a9/locust_cloud-1.21.9.tar.gz", hash = "sha256:f3c81447cadfb533d1e2bbdbf95fac97316233cbbde779df56a7b447d77bd8ea", size = 450609, upload-time = "2025-05-28T13:31:32.755Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/69/cb/db2d9dd27317d22d98f7a4a0eebbe4dc6ff24e44c0ae509118370e605c3b/locust_cloud-1.23.0.tar.gz", hash = "sha256:4038a09eda858b483ced20f5cb82caf3f866244c2c7864e0da5c32722b97f532", size = 450778, upload-time = "2025-06-03T08:12:01.169Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3c/d6/88f69bae4ad908ebd381463a0530cd2586dd4efbea58711f069165983f51/locust_cloud-1.21.9-py3-none-any.whl", hash = "sha256:a81351ee6dd8071c3eb28bfafb1325273462dff037e8105896559ae3db4092c1", size = 408075, upload-time = "2025-05-28T13:31:31.297Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/d8/0f633e39ed3f3237430c6bcb9d18402dea6bef7eaa60a484cd1d4d939e81/locust_cloud-1.23.0-py3-none-any.whl", hash = "sha256:936cc4feb0b0dd89e113f6318a1205f318ed49a9df4e0feca8d40f2d9b353d30", size = 408308, upload-time = "2025-06-03T08:11:58.228Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -295,11 +295,11 @@ wheels = [
 
 [[package]]
 name = "configargparse"
-version = "1.7"
+version = "1.7.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/70/8a/73f1008adfad01cb923255b924b1528727b8270e67cb4ef41eabdc7d783e/ConfigArgParse-1.7.tar.gz", hash = "sha256:e7067471884de5478c58a511e529f0f9bd1c66bfef1dea90935438d6c23306d1", size = 43817, upload-time = "2023-07-23T16:20:04.95Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/85/4d/6c9ef746dfcc2a32e26f3860bb4a011c008c392b83eabdfb598d1a8bbe5d/configargparse-1.7.1.tar.gz", hash = "sha256:79c2ddae836a1e5914b71d58e4b9adbd9f7779d4e6351a637b7d2d9b6c46d3d9", size = 43958, upload-time = "2025-05-23T14:26:17.369Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6f/b3/b4ac838711fd74a2b4e6f746703cf9dd2cf5462d17dac07e349234e21b97/ConfigArgParse-1.7-py3-none-any.whl", hash = "sha256:d249da6591465c6c26df64a9f73d2536e743be2f244eb3ebe61114af2f94f86b", size = 25489, upload-time = "2023-07-23T16:20:03.27Z" },
+    { url = "https://files.pythonhosted.org/packages/31/28/d28211d29bcc3620b1fece85a65ce5bb22f18670a03cd28ea4b75ede270c/configargparse-1.7.1-py3-none-any.whl", hash = "sha256:8b586a31f9d873abd1ca527ffbe58863c99f36d896e2829779803125e83be4b6", size = 25607, upload-time = "2025-05-23T14:26:15.923Z" },
 ]
 
 [[package]]
@@ -914,13 +914,13 @@ test = [
 
 [package.metadata]
 requires-dist = [
-    { name = "configargparse", specifier = ">=1.5.5" },
+    { name = "configargparse", specifier = ">=1.7.1" },
     { name = "flask", specifier = ">=2.0.0" },
     { name = "flask-cors", specifier = ">=3.0.10" },
     { name = "flask-login", specifier = ">=0.6.3" },
     { name = "gevent", specifier = ">=24.10.1,<25.0.0" },
     { name = "geventhttpclient", specifier = ">=2.3.1" },
-    { name = "locust-cloud", specifier = ">=1.21.8" },
+    { name = "locust-cloud", specifier = ">=1.21.9" },
     { name = "msgpack", specifier = ">=1.0.0" },
     { name = "psutil", specifier = ">=5.9.1" },
     { name = "pywin32", marker = "sys_platform == 'win32'" },
@@ -975,7 +975,7 @@ test = [
 
 [[package]]
 name = "locust-cloud"
-version = "1.21.8"
+version = "1.21.9"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "configargparse" },
@@ -984,9 +984,9 @@ dependencies = [
     { name = "python-socketio", extra = ["client"] },
     { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/09/d4/64a169b4831d26ab9dceacb192ea30c749501d87b4958e628cf1f7ef45c4/locust_cloud-1.21.8.tar.gz", hash = "sha256:e8bde0da013c8731a45cc834cdf9fec2fc21738a5f2807d93c2c5eeb3008a80e", size = 450414, upload-time = "2025-05-22T08:30:27.458Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/54/71/4f3dec44c419f7e5706e117fae7dda7c17d440d873c5e68aeb5843b7c9a9/locust_cloud-1.21.9.tar.gz", hash = "sha256:f3c81447cadfb533d1e2bbdbf95fac97316233cbbde779df56a7b447d77bd8ea", size = 450609, upload-time = "2025-05-28T13:31:32.755Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/06/76/aa8b2f73bdf7de5ee344e5d0c4749e8d62ff38257b41d9df37b0b7ac84e2/locust_cloud-1.21.8-py3-none-any.whl", hash = "sha256:4f06b5d8a26ba91840a768008f4870965b13cc71481de9797409556de2edc007", size = 407879, upload-time = "2025-05-22T08:30:25.512Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/d6/88f69bae4ad908ebd381463a0530cd2586dd4efbea58711f069165983f51/locust_cloud-1.21.9-py3-none-any.whl", hash = "sha256:a81351ee6dd8071c3eb28bfafb1325273462dff037e8105896559ae3db4092c1", size = 408075, upload-time = "2025-05-28T13:31:31.297Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -920,7 +920,7 @@ requires-dist = [
     { name = "flask-login", specifier = ">=0.6.3" },
     { name = "gevent", specifier = ">=24.10.1,<25.0.0" },
     { name = "geventhttpclient", specifier = ">=2.3.1" },
-    { name = "locust-cloud", specifier = ">=1.21.7" },
+    { name = "locust-cloud", specifier = ">=1.21.8" },
     { name = "msgpack", specifier = ">=1.0.0" },
     { name = "psutil", specifier = ">=5.9.1" },
     { name = "pywin32", marker = "sys_platform == 'win32'" },
@@ -975,7 +975,7 @@ test = [
 
 [[package]]
 name = "locust-cloud"
-version = "1.21.7"
+version = "1.21.8"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "configargparse" },
@@ -984,9 +984,9 @@ dependencies = [
     { name = "python-socketio", extra = ["client"] },
     { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/11/d1/29e785fbe2ac6b1eda03b39709e5c898d82bd10495d181c95c0f038cb0ae/locust_cloud-1.21.7.tar.gz", hash = "sha256:a919e93e514ae48a3dd4791945188b9df6369122afc3d7d21447aafb8daa3f87", size = 450230, upload-time = "2025-05-15T14:09:51.283Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/09/d4/64a169b4831d26ab9dceacb192ea30c749501d87b4958e628cf1f7ef45c4/locust_cloud-1.21.8.tar.gz", hash = "sha256:e8bde0da013c8731a45cc834cdf9fec2fc21738a5f2807d93c2c5eeb3008a80e", size = 450414, upload-time = "2025-05-22T08:30:27.458Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/33/8d/98853ef23e96bb9372226492b40d28a1df650a064122c84e586ab267fa12/locust_cloud-1.21.7-py3-none-any.whl", hash = "sha256:93e93212a0726b8b7481ddbf82c64f5b1c7c2eb8f3c12de95834fe6ef445eb5e", size = 407883, upload-time = "2025-05-15T14:09:49.861Z" },
+    { url = "https://files.pythonhosted.org/packages/06/76/aa8b2f73bdf7de5ee344e5d0c4749e8d62ff38257b41d9df37b0b7ac84e2/locust_cloud-1.21.8-py3-none-any.whl", hash = "sha256:4f06b5d8a26ba91840a768008f4870965b13cc71481de9797409556de2edc007", size = 407879, upload-time = "2025-05-22T08:30:25.512Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
# PR Summary

Refactor parse_locustfile_option Function

## Overview

This PR refactors the `parse_locustfile_option` function in the argument parser module by breaking it into smaller, more focused functions and changing its return value from a list to a tuple.

## Change Types

| Type         | Description                            |
|--------------|----------------------------------------|
| Refactor     | Restructure parse_locustfile_option function for better maintainability |

---

## Affected Modules

| Module / File          | Change Description                       |
|------------------------|------------------------------------------|
| `argument_parser.py`   | Refactored parse_locustfile_option function, changed return type from list to tuple |
| `test/util.py`         | Added imports for get_locustfiles_locally and parse_locustfile_option |